### PR TITLE
feat: change debounce to use lodash ES package to avoid CommonJS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "debounce": "^1.2.1"
+    "lodash-es": "4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import debounce from 'debounce';
+import { debounce } from 'lodash-es';
 
 class Prop {
   constructor(name, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,11 +1128,6 @@ core-js-compat@^3.25.1:
   dependencies:
     browserslist "^4.21.4"
 
-debounce@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
-  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
-
 debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1276,6 +1271,11 @@ json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+lodash-es@4:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
+ This replaces debounce with lodash-es debounce
+ This avoids the use of CommonJS dependencies which can cause optimization and tree shaking problems