### PR TITLE
Reduce bundle size by importing lodash/debounce directly.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash-es';
+import debounce from 'lodash-es/debounce';
 
 class Prop {
   constructor(name, {


### PR DESCRIPTION
kapsule's bundle size is mostly composed of lodash. Importing the only used function "debounce" directly greatly reduces it, and in the case of three-shaken outputs, reduces the amount of imports to parse and files to read (tested with esbuild).

<img width="1258" alt="Screenshot 2023-05-17 at 15 31 43" src="https://github.com/vasturiano/kapsule/assets/911097/209a8514-aef6-495b-a8b6-8a82fea1f690">
